### PR TITLE
Introduce `Executor`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,4 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 1

--- a/.github/workflows/quality-check.yml
+++ b/.github/workflows/quality-check.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-latest, macos-latest, windows-latest]
+        platform: [ubuntu-latest, macos-latest]
         python-version: [3.9]
     defaults:
       run:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0]
+
+### Changed
+
+- Command output now wraps separately from the prefix [#12](https://github.com/JoshKarpel/brood/pull/12).
+- The process status table in the `log` renderer can now be disabled via configuration [#14](https://github.com/JoshKarpel/brood/pull/14).
+
+### Removed
+
+- Command output can no longer be given an overall style via configuration [#12](https://github.com/JoshKarpel/brood/pull/12).
+
 ## [0.1.0]
 
 ### Added
 
 - Run commands concurrently based on a configuration file.
 - Run non-daemonic commands with restart loops or with file watching.
-- Display process health in a live-updating table, with console output streaming above it.
+- Display process status in a live-updating table, with console output streaming above it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Command output now wraps separately from the prefix [#12](https://github.com/JoshKarpel/brood/pull/12).
 - The process status table in the `log` renderer can now be disabled via configuration [#14](https://github.com/JoshKarpel/brood/pull/14).
+- `brood run` now exits with code 0 when sent a keyboard interrupt (`Ctrl-C`) [#14](https://github.com/JoshKarpel/brood/pull/14).
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -11,3 +11,9 @@
 
 A flexible concurrent command runner,
 inspired by [Concurrently](https://github.com/open-cli-tools/concurrently) and powered by [Rich](https://github.com/willmcgugan/rich).
+
+
+## Platform Support
+
+Brood currently supports POSIX systems like Linux and MacOS.
+You can try to run it on Windows, but it probably won't work!

--- a/brood/command.py
+++ b/brood/command.py
@@ -1,18 +1,11 @@
 from __future__ import annotations
 
 import os
-from asyncio import (
-    FIRST_COMPLETED,
-    CancelledError,
-    Task,
-    create_subprocess_shell,
-    create_task,
-    wait,
-)
+from asyncio import CancelledError, Task, create_subprocess_shell, create_task
 from asyncio.subprocess import PIPE, STDOUT, Process
 from dataclasses import dataclass, field
 from enum import Enum
-from signal import SIGINT, SIGKILL, SIGTERM
+from signal import SIGKILL, SIGTERM
 from typing import Optional
 
 from brood.config import CommandConfig

--- a/brood/config.py
+++ b/brood/config.py
@@ -77,10 +77,6 @@ class CommandConfig(BaseConfig):
         default=None,
         description=f"The Rich style to apply to the prefix. Defaults to the renderer's 'prefix_style'.",
     )
-    message_style: Optional[str] = Field(
-        default=None,
-        description=f"The Rich style to apply to each line of output from this command. Defaults to the renderer's 'message_style'.",
-    )
 
     starter: Union[OnceConfig, RestartConfig, WatchConfig] = RestartConfig()
 

--- a/brood/config.py
+++ b/brood/config.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import shlex
 from enum import Enum
+from functools import cached_property
 from pathlib import Path
 from typing import Any, ClassVar, Dict, List, Literal, Optional, Set, Union
 

--- a/brood/config.py
+++ b/brood/config.py
@@ -91,6 +91,13 @@ class CommandConfig(BaseConfig):
         else:
             return self.command
 
+    @property
+    def shutdown_config(self) -> Optional[CommandConfig]:
+        if self.shutdown is None:
+            return None
+
+        return self.copy(update={"command": self.shutdown, "starter": OnceConfig()})
+
 
 class RendererConfig(BaseConfig):
     pass

--- a/brood/config.py
+++ b/brood/config.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import shlex
 from enum import Enum
-from functools import cached_property
 from pathlib import Path
 from typing import Any, ClassVar, Dict, List, Literal, Optional, Set, Union
 

--- a/brood/executor.py
+++ b/brood/executor.py
@@ -33,7 +33,6 @@ class Executor:
             config=self.config,
             events=self.events,
             messages=self.messages,
-            events_consumer=self.events.consumer(),
             widths={
                 **{
                     config: self.renderer.available_process_width(config)

--- a/brood/executor.py
+++ b/brood/executor.py
@@ -11,7 +11,7 @@ from brood.config import BroodConfig
 from brood.fanout import Fanout
 from brood.message import InternalMessage, Message
 from brood.monitor import KillOthers, Monitor
-from brood.renderer import RENDERERS, Renderer
+from brood.renderer import RENDERERS
 
 
 class Executor:

--- a/brood/executor.py
+++ b/brood/executor.py
@@ -96,4 +96,4 @@ class Executor:
 
         await self.renderer.unmount()
 
-        return None
+        return True

--- a/brood/executor.py
+++ b/brood/executor.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from asyncio import FIRST_EXCEPTION, CancelledError, create_task, wait
+from types import TracebackType
+from typing import Optional, Type
+
+from rich.console import Console
+
+from brood.command import Event
+from brood.config import BroodConfig
+from brood.fanout import Fanout
+from brood.message import InternalMessage, Message
+from brood.monitor import KillOthers, Monitor
+from brood.renderer import RENDERERS, Renderer
+
+
+class Executor:
+    def __init__(self, config: BroodConfig, console: Console):
+        self.config = config
+        self.console = console
+
+        self.events: Fanout[Event] = Fanout()
+        self.messages: Fanout[Message] = Fanout()
+
+        self.renderer = RENDERERS[config.renderer.type](
+            config=self.config.renderer,
+            console=self.console,
+            events=self.events.consumer(),
+            messages=self.messages.consumer(),
+        )
+
+        self.monitor = Monitor(
+            config=self.config,
+            events=self.events,
+            messages=self.messages,
+            events_consumer=self.events.consumer(),
+            widths={
+                **{
+                    config: self.renderer.available_process_width(config)
+                    for config in self.config.commands
+                }
+            },
+        )
+
+    async def run(self) -> None:
+        done, pending = await wait(
+            (
+                self.monitor.run(),
+                self.renderer.mount(),
+                self.renderer.run(),
+            ),
+            return_when=FIRST_EXCEPTION,
+        )
+
+        for d in done:
+            d.result()
+
+    async def __aenter__(self) -> Executor:
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> Optional[bool]:
+        if exc_val:
+            if exc_type is CancelledError:
+                text = f"Shutting down due to: keyboard interrupt"
+            elif exc_type is KillOthers:
+                text = f"Shutting down due to: command failing"
+            else:
+                text = f"Shutting down due to: {exc_type.__name__}"
+            await self.messages.put(InternalMessage(text))
+
+        await self.monitor.stop()
+
+        await self.renderer.run(drain=True)
+
+        await self.renderer.unmount()
+
+        return True

--- a/brood/main.py
+++ b/brood/main.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import shutil
+import sys
 from pathlib import Path
 
 from rich.console import Console

--- a/brood/main.py
+++ b/brood/main.py
@@ -1,19 +1,15 @@
 import asyncio
 import logging
-import shutil
-import sys
 from pathlib import Path
 
 from rich.console import Console
 from rich.json import JSON
 from rich.panel import Panel
-from rich.traceback import install
 from typer import Argument, Option, Typer
 
 from brood.config import BroodConfig
 from brood.constants import PACKAGE_NAME, __version__
 from brood.executor import Executor
-from brood.monitor import Monitor
 
 app = Typer()
 

--- a/brood/main.py
+++ b/brood/main.py
@@ -11,6 +11,7 @@ from typer import Argument, Option, Typer
 
 from brood.config import BroodConfig
 from brood.constants import PACKAGE_NAME, __version__
+from brood.executor import Executor
 from brood.monitor import Monitor
 
 app = Typer()
@@ -40,7 +41,7 @@ def run(
     Execute a configuration.
     """
     console = Console()
-    install(console=console, show_locals=True, width=shutil.get_terminal_size().columns)
+    # install(console=console, show_locals=True, width=shutil.get_terminal_size().columns)
 
     config = BroodConfig.load(config_path)
 
@@ -65,8 +66,8 @@ def run(
 
 
 async def _run(config: BroodConfig, console: Console) -> None:
-    async with Monitor.create(config=config, console=console) as monitor:
-        await monitor.run()
+    async with Executor(config=config, console=console) as executor:
+        await executor.run()
 
 
 @app.command()

--- a/brood/monitor.py
+++ b/brood/monitor.py
@@ -1,25 +1,14 @@
 from __future__ import annotations
 
-from asyncio import FIRST_EXCEPTION, CancelledError, Queue, gather, get_running_loop, wait
+from asyncio import FIRST_EXCEPTION, Queue, gather, get_running_loop, wait
 from dataclasses import dataclass, field
 from functools import partial
-from types import TracebackType
-from typing import AsyncContextManager, List, Mapping, Optional, Set, Type
-
-from rich.console import Console
+from typing import List, Mapping, Set
 
 from brood.command import CommandManager, Event, EventType
-from brood.config import (
-    BroodConfig,
-    CommandConfig,
-    FailureMode,
-    OnceConfig,
-    RestartConfig,
-    WatchConfig,
-)
+from brood.config import BroodConfig, CommandConfig, FailureMode, RestartConfig, WatchConfig
 from brood.fanout import Fanout
 from brood.message import InternalMessage, Message
-from brood.renderer import RENDERERS, Renderer
 from brood.utils import delay, drain_queue
 from brood.watch import FileWatcher, StartCommandHandler, WatchEvent
 

--- a/brood/renderer.py
+++ b/brood/renderer.py
@@ -21,7 +21,7 @@ from rich.style import Style
 from rich.table import Table
 from rich.text import Text
 
-from brood.command import CommandManager, Event, EventType
+from brood.command import Command, Event, EventType
 from brood.config import CommandConfig, LogRendererConfig, RendererConfig
 from brood.message import CommandMessage, InternalMessage, Message
 from brood.utils import delay
@@ -163,7 +163,7 @@ class TimeElapsedColumn(ProgressColumn):
 class LogRenderer(Renderer):
     config: LogRendererConfig
 
-    status_bars: Dict[CommandManager, Progress] = field(default_factory=dict)
+    status_bars: Dict[Command, Progress] = field(default_factory=dict)
     stop_tasks: List[asyncio.Task[None]] = field(default_factory=list)
 
     def prefix_width(self, command_config: CommandConfig) -> int:
@@ -214,8 +214,8 @@ class LogRenderer(Renderer):
             TimeElapsedColumn(),
             RenderableColumn(
                 Text(
-                    event.manager.command_config.command_string,
-                    style=event.manager.command_config.prefix_style or self.config.prefix_style,
+                    event.manager.config.command_string,
+                    style=event.manager.config.prefix_style or self.config.prefix_style,
                 )
             ),
             console=self.console,
@@ -243,7 +243,7 @@ class LogRenderer(Renderer):
 
         self.stop_tasks.append(delay(10, partial(self.remove_status_bar, manager=event.manager)))
 
-    async def remove_status_bar(self, manager: CommandManager, delay: int = 10) -> None:
+    async def remove_status_bar(self, manager: Command, delay: int = 10) -> None:
         self.status_bars.pop(manager, None)
 
         self.update_live()

--- a/brood/renderer.py
+++ b/brood/renderer.py
@@ -142,6 +142,7 @@ class NullRenderer(Renderer):
         return shutil.get_terminal_size().columns
 
 
+DOTS = ["dots"] + [f"dots{n}" for n in range(2, 12)]
 GREEN_CHECK = Text("✔", style="green")
 RED_X = Text("✘", style="red")
 
@@ -188,7 +189,7 @@ class LogRenderer(Renderer):
         for k, v in sorted(self.status_bars.items(), key=lambda kv: kv[0].process.pid):
             table.add_row(v)  # type: ignore
 
-        self.live.update(Group(Rule(style="dim"), table))
+        self.live.update(Group(Rule(style="dim"), table), refresh=True)
 
     async def mount(self) -> None:
         if not self.config.status_tracker:
@@ -207,7 +208,7 @@ class LogRenderer(Renderer):
             return
 
         p = Progress(
-            SpinnerColumn(spinner_name=choice(["dots"] + [f"dots{n}" for n in range(2, 12)])),
+            SpinnerColumn(spinner_name=choice(DOTS), style=NULL_STYLE),
             RenderableColumn(Text("  ?", style="dim")),
             RenderableColumn(Text(str(event.manager.process.pid).rjust(5), style="dim")),
             TimeElapsedColumn(),

--- a/brood/renderer.py
+++ b/brood/renderer.py
@@ -158,9 +158,6 @@ class TimeElapsedColumn(ProgressColumn):
         return Text(str(delta), style="dim")
 
 
-DIM_RULE = Rule(style="dim")
-
-
 @dataclass(frozen=True)
 class LogRenderer(Renderer):
     config: LogRendererConfig
@@ -191,7 +188,7 @@ class LogRenderer(Renderer):
         for k, v in sorted(self.status_bars.items(), key=lambda kv: kv[0].process.pid):
             table.add_row(v)  # type: ignore
 
-        self.live.update(Group(DIM_RULE, table))
+        self.live.update(Group(Rule(style="dim"), table))
 
     async def mount(self) -> None:
         if not self.config.status_tracker:

--- a/brood/renderer.py
+++ b/brood/renderer.py
@@ -74,7 +74,7 @@ class Renderer:
     messages: Queue[Message]
     events: Queue[Event]
 
-    def available_process_width(self, command: CommandConfig) -> int:
+    def available_process_width(self, command_config: CommandConfig) -> int:
         raise NotImplementedError
 
     async def mount(self) -> None:
@@ -138,7 +138,7 @@ class Renderer:
 
 @dataclass(frozen=True)
 class NullRenderer(Renderer):
-    def available_process_width(self, command: CommandConfig) -> int:
+    def available_process_width(self, command_config: CommandConfig) -> int:
         return shutil.get_terminal_size().columns
 
 

--- a/examples/exit-on-fail.yaml
+++ b/examples/exit-on-fail.yaml
@@ -6,3 +6,5 @@ commands:
   - name: "echo"
     command: "sleep 5; echo nope"
     prefix_style: "green"
+
+failure_mode: "kill_others"

--- a/examples/exit-on-fail.yaml
+++ b/examples/exit-on-fail.yaml
@@ -4,7 +4,11 @@ commands:
     prefix_style: "red"
 
   - name: "echo"
-    command: "sleep 5; echo nope"
+    command: "python -c 'import time; [(time.sleep(1), print(1)) for _ in range(3)]' && echo nope"
     prefix_style: "green"
+
+renderer:
+  type: "log"
+  status_tracker: false
 
 failure_mode: "kill_others"

--- a/examples/starters.yaml
+++ b/examples/starters.yaml
@@ -12,6 +12,7 @@ commands:
 
   - name: "long"
     command: "echo start && sleep 10 && echo done"
+    shutdown: "sleep 3 && echo shutdown"
     prefix_style: "cyan"
     starter:
       type: "watch"

--- a/examples/starters.yaml
+++ b/examples/starters.yaml
@@ -1,6 +1,6 @@
 commands:
   - name: "restart"
-    command: "echo timer ; mkdir -p /tmp/foobar ; echo foo > /tmp/foobar/test"
+    command: "echo timer && mkdir -p /tmp/foobar && echo foo > /tmp/foobar/test"
     prefix_style: "green"
 
   - name: "watch"
@@ -11,9 +11,13 @@ commands:
       paths: ["/tmp/foobar"]
 
   - name: "long"
-    command: "echo start; sleep 10; echo done"
+    command: "echo start && sleep 10 && echo done"
     prefix_style: "cyan"
     starter:
       type: "watch"
       paths: ["/tmp/foobar"]
       allow_multiple: false
+
+renderer:
+  type: "log"
+  status_tracker: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: MacOS",
     "Operating System :: Unix",
-    "Operating System :: Microsoft :: Windows",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Intended Audience :: Developers",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "brood"
-version = "0.1.0"
+version = "0.2.0"
 description = "A flexible concurrent command runner."
 readme="README.md"
 license = "MIT"

--- a/tests/test_command_manager.py
+++ b/tests/test_command_manager.py
@@ -3,7 +3,7 @@ from typing import Tuple
 
 import pytest
 
-from brood.command import CommandManager, Event
+from brood.command import Command, Event
 from brood.config import CommandConfig, OnceConfig
 from brood.constants import ON_WINDOWS
 from brood.fanout import Fanout
@@ -20,63 +20,73 @@ def once_config(command: str) -> CommandConfig:
     )
 
 
-@pytest.fixture
-async def once_manager_(once_config: CommandConfig) -> Tuple[CommandManager, Queue[Message]]:
-    process_events_fanout: Fanout[Event] = Fanout()
+PackedManagerFixtureOutput = Tuple[Command, Queue[Event], Queue[Message]]
 
-    messages_fanout: Fanout[Message] = Fanout()
-    messages_consumer = messages_fanout.consumer()
+
+@pytest.fixture
+async def once_manager_(once_config: CommandConfig) -> PackedManagerFixtureOutput:
+    events: Fanout[Event] = Fanout()
+    events_consumer = events.consumer()
+
+    messages: Fanout[Message] = Fanout()
+    messages_consumer = messages.consumer()
 
     return (
-        await CommandManager.start(
-            command_config=once_config,
-            events=process_events_fanout,
-            messages=messages_fanout,
+        await Command.start(
+            config=once_config,
+            events=events,
+            messages=messages,
             width=80,
         ),
+        events_consumer,
         messages_consumer,
     )
 
 
 @pytest.fixture
-def once_manager(once_manager_: Tuple[CommandManager, Queue[Message]]) -> CommandManager:
+def once_manager(once_manager_: PackedManagerFixtureOutput) -> Command:
     return once_manager_[0]
 
 
 @pytest.fixture
-def messages(once_manager_: Tuple[CommandManager, Queue[Message]]) -> Queue[Message]:
+def events(once_manager_: PackedManagerFixtureOutput) -> Queue[Event]:
     return once_manager_[1]
+
+
+@pytest.fixture
+def messages(once_manager_: PackedManagerFixtureOutput) -> Queue[Message]:
+    return once_manager_[2]
 
 
 @pytest.mark.parametrize("command", ["echo hi", "echo hi 1>&2"])
 async def test_command_output_captured_as_command_message(
-    once_manager: CommandManager, messages: Queue[Message], command: str
+    once_manager: Command, messages: Queue[Message], command: str
 ) -> None:
     await once_manager.wait()
 
-    command_messages = [
-        message for message in await drain_queue(messages) if isinstance(message, CommandMessage)
-    ]
+    drained = await drain_queue(messages)
+    print(drained)
+
+    command_messages = [message for message in drained if isinstance(message, CommandMessage)]
+    print(command_messages)
 
     assert len(command_messages) == 1
 
     message = command_messages[0]
 
     assert message.text == "hi"
-    assert message.command_config is once_manager.command_config
+    assert message.command_config is once_manager.config
 
 
 @pytest.mark.parametrize("command, exit_code", [("exit 0", 0), ("exit 1", 1)])
-async def test_capture_exit_code(
-    once_manager: CommandManager, command: str, exit_code: int
-) -> None:
+async def test_capture_exit_code(once_manager: Command, command: str, exit_code: int) -> None:
     await once_manager.wait()
 
     assert once_manager.exit_code == exit_code
 
 
 @pytest.mark.parametrize("command", ["sleep 1"])
-async def test_has_exited_lifecycle(once_manager: CommandManager, command: str) -> None:
+async def test_has_exited_lifecycle(once_manager: Command, command: str) -> None:
     assert not once_manager.has_exited
 
     await once_manager.wait()
@@ -85,7 +95,7 @@ async def test_has_exited_lifecycle(once_manager: CommandManager, command: str) 
 
 
 @pytest.mark.parametrize("command", ["sleep 1000"])
-async def test_can_terminate_before_completion(once_manager: CommandManager, command: str) -> None:
+async def test_can_terminate_before_completion(once_manager: Command, command: str) -> None:
     await once_manager.terminate()
 
     await once_manager.wait()
@@ -94,7 +104,7 @@ async def test_can_terminate_before_completion(once_manager: CommandManager, com
 
 
 @pytest.mark.parametrize("command", ["sleep 1000"])
-async def test_can_kill_before_completion(once_manager: CommandManager, command: str) -> None:
+async def test_can_kill_before_completion(once_manager: Command, command: str) -> None:
     await once_manager.kill()
 
     await once_manager.wait()
@@ -103,14 +113,14 @@ async def test_can_kill_before_completion(once_manager: CommandManager, command:
 
 
 @pytest.mark.parametrize("command", ["echo hi"])
-async def test_can_stop_after_exit(once_manager: CommandManager, command: str) -> None:
+async def test_can_stop_after_exit(once_manager: Command, command: str) -> None:
     await once_manager.wait()
 
     await once_manager.terminate()
 
 
 @pytest.mark.parametrize("command", ["echo hi"])
-async def test_can_kill_after_exit(once_manager: CommandManager, command: str) -> None:
+async def test_can_kill_after_exit(once_manager: Command, command: str) -> None:
     await once_manager.wait()
 
     await once_manager.kill()


### PR DESCRIPTION
Introduces an `Executor` class which owns the `Monitor` and `Renderer`, thus freeing the monitor of needing to know about the `Renderer`, expect indirectly through figuring out the available width for each process.